### PR TITLE
Try to fix bug(?) while render centered sprite

### DIFF
--- a/kgfx.cpp
+++ b/kgfx.cpp
@@ -69,15 +69,20 @@ void KGFX::drawText(TFT_eSprite &spr, const char *txt, const tftfont_t &f, int c
 void KGFX::drawTextCenter(TFT_eSprite &spr, const char *txt, const tftfont_t &f, int color, int y)
 {
   tft.TTFdestination(&spr);
-  spr.fillSprite(TFT_BLACK); // Do not fill sprite with black, it will overwrite the sprite
+  spr.fillSprite(TFT_BLACK);
   
   tft.setTTFFont(f);
   tft.setTextColor(color, TFT_BLACK);
-  int x = tft.width() / 2 - tft.TTFtextWidth(txt) / 2;
-  tft.setCursor(0,0);
+
+  int w = tft.TTFtextWidth(txt); 
+  int h = tft.TTFtextWidth(txt);
+  int x1 = (spr.width() - w)/2; // center text in sprite
+  int x2 = (tft.width() - spr.width)/2; // center sprite on screen
+
+  tft.setCursor(x1, 0);
   tft.print(txt);
-  
-  spr.pushSprite(x, y);
+
+  spr.pushSprite(x2, y);
 }
 
 /***************************************************************************************

--- a/kgfx.cpp
+++ b/kgfx.cpp
@@ -70,7 +70,7 @@ void KGFX::drawTextCenter(TFT_eSprite &spr, const char *txt, const tftfont_t &f,
 {
   tft.TTFdestination(&spr);
   spr.fillSprite(TFT_BLACK);
-  
+
   tft.setTTFFont(f);
   tft.setTextColor(color, TFT_BLACK);
 

--- a/kgfx.cpp
+++ b/kgfx.cpp
@@ -70,14 +70,14 @@ void KGFX::drawTextCenter(TFT_eSprite &spr, const char *txt, const tftfont_t &f,
 {
   tft.TTFdestination(&spr);
   spr.fillSprite(TFT_BLACK); // Do not fill sprite with black, it will overwrite the sprite
-
+  
   tft.setTTFFont(f);
   tft.setTextColor(color, TFT_BLACK);
   int x = tft.width() / 2 - tft.TTFtextWidth(txt) / 2;
-  tft.setCursor(x, y);
+  tft.setCursor(0,0);
   tft.print(txt);
-
-  spr.pushSprite(0, 0);
+  
+  spr.pushSprite(x, y);
 }
 
 /***************************************************************************************

--- a/kgfx.cpp
+++ b/kgfx.cpp
@@ -75,7 +75,6 @@ void KGFX::drawTextCenter(TFT_eSprite &spr, const char *txt, const tftfont_t &f,
   tft.setTextColor(color, TFT_BLACK);
 
   int w = tft.TTFtextWidth(txt); 
-  int h = tft.TTFtextWidth(txt);
   int x1 = (spr.width() - w)/2; // center text in sprite
   int x2 = (tft.width() - spr.width)/2; // center sprite on screen
 


### PR DESCRIPTION
I tried to use function provided by @davidgs which is awesome but I think it might not work as intended and will work only while it is on top of the screen since it always render entire sprite at 0,0 and using sprite canvas to center it. ( I am new to this so please correct me if I am wrong)